### PR TITLE
damn ugly fix to image not found libggit2.0.dylib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 git2go
 libgit2
 gitql
+libgit2.0.dylib
+runtime/libgit2.0.dylib

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ prepare: clean
 	@echo "Preparing...\n"
 	chmod +x $(GOPATH)/src/github.com/libgit2/git2go/script/build-libgit2.sh
 	$(GOPATH)/src/github.com/libgit2/git2go/script/build-libgit2.sh
+	cp libgit2/libgit2.0.dylib ./
+	cp libgit2/libgit2.0.dylib ./runtime
 
 build: 
 	go build


### PR DESCRIPTION
Fixes the error `dyld: Library not loaded: libgit2.0.dylib`
Currently copying the `dylib` to two different places to prevent braking the tests as well... there should be a better way.
