### PR TITLE
prevent crash if no argument is given

### DIFF
--- a/gitql.go
+++ b/gitql.go
@@ -22,6 +22,11 @@ func main() {
 		return 
 	}
 
+  if *query == "" {
+    flag.Usage()
+    return
+  }
+
 	path, errFile := filepath.Abs(*pathString)
 
 	if errFile != nil {


### PR DESCRIPTION
Show the help message instead.
Maybe it should accept the string straight away by default...
