### PR TITLE
Adding support to json

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,4 @@ Notes:
 * The limit default is 10 rows  
 * It's inspired by [textql](https://github.com/dinedal/textql)   
 * But, why gitql is a compiler/interpreter instead of just read a sqlite database with all commits, tags and etc? Answer: Because we would need to sync the tables every time before run sql and we would have sqlite bases for each repository. :neutral_face:
+

--- a/cmd.go
+++ b/cmd.go
@@ -4,7 +4,7 @@ import (
     "flag"
     "os"
     "fmt"
-    "github.com/luizperes/gitql/runtime"
+    "github.com/cloudson/gitql/runtime"
 )
 
 var path *string

--- a/cmd.go
+++ b/cmd.go
@@ -9,6 +9,7 @@ import (
 
 var path *string
 var query string
+var genJson *bool
 
 func init() {
     parseCommandLine()
@@ -32,17 +33,18 @@ func printTables() {
             if i + 1 < len(fields) {
                 comma = ", "
             }
-            fmt.Printf("%s%s", field, comma)            
+            fmt.Printf("%s%s", field, comma)
         }
         fmt.Println()
     }
-    
+
 }
 
 func parseCommandLine() {
     path = flag.String("p", ".", "The (optional) path to run gitql")
     version := flag.Bool("v", false, "The version of gitql")
     showTables := flag.Bool("show-tables", false, "Show all tables")
+    genJson = flag.Bool("json", false, "Generate JSON")
     flag.Usage = usage
     flag.Parse()
 

--- a/cmd.go
+++ b/cmd.go
@@ -4,12 +4,12 @@ import (
     "flag"
     "os"
     "fmt"
-    "github.com/cloudson/gitql/runtime"
+    "github.com/luizperes/gitql/runtime"
 )
 
 var path *string
 var query string
-var genJson *bool
+var typeFormat *string
 
 func init() {
     parseCommandLine()
@@ -44,7 +44,7 @@ func parseCommandLine() {
     path = flag.String("p", ".", "The (optional) path to run gitql")
     version := flag.Bool("v", false, "The version of gitql")
     showTables := flag.Bool("show-tables", false, "Show all tables")
-    genJson = flag.Bool("json", false, "Generate JSON")
+    typeFormat = flag.String("type", "table", "The output type format {table|json}")
     flag.Usage = usage
     flag.Parse()
 

--- a/gitql.go
+++ b/gitql.go
@@ -26,5 +26,5 @@ func main() {
 		log.Fatalln(errGit)
 	}
 
-	runtime.Run(ast, genJson)
+	runtime.Run(ast, typeFormat)
 }

--- a/gitql.go
+++ b/gitql.go
@@ -26,5 +26,5 @@ func main() {
 		log.Fatalln(errGit)
 	}
 
-	runtime.Run(ast)
+	runtime.Run(ast, genJson)
 }

--- a/runtime/commits.go
+++ b/runtime/commits.go
@@ -8,7 +8,7 @@ import (
     "strings"
 )
 
-func walkCommits(n *parser.NodeProgram, visitor *RuntimeVisitor) {
+func walkCommits(n *parser.NodeProgram, visitor *RuntimeVisitor) *TableData{
     builder.walk, _ = repo.Walk()
     builder.walk.PushHead()
     builder.walk.Sorting(git.SortTime)
@@ -57,7 +57,10 @@ func walkCommits(n *parser.NodeProgram, visitor *RuntimeVisitor) {
         }
         rowsSliced = rowsSliced[0:counter]
     }
-    printTable(rowsSliced, fields)
+    tableData := new(TableData)
+    tableData.rows = rowsSliced
+    tableData.fields = fields
+    return tableData
 }
 
 func metadataCommit(identifier string, object *git.Commit) string {

--- a/runtime/reference.go
+++ b/runtime/reference.go
@@ -6,7 +6,7 @@ import (
     "log"
 )
 
-func walkReferences(n *parser.NodeProgram, visitor *RuntimeVisitor) {
+func walkReferences(n *parser.NodeProgram, visitor *RuntimeVisitor) *TableData{
     s := n.Child.(*parser.NodeSelect)
     where := s.Where
 
@@ -54,8 +54,11 @@ func walkReferences(n *parser.NodeProgram, visitor *RuntimeVisitor) {
         }
         rowsSliced = rowsSliced[0:counter]
     }
-    printTable(rowsSliced, fields)
-}
+    tableData := new(TableData)
+    tableData.rows = rowsSliced
+    tableData.fields = fields
+    return tableData
+  }
 
 func metadataReference(identifier string, object *git.Reference) string {
     key := ""

--- a/runtime/remotes.go
+++ b/runtime/remotes.go
@@ -1,4 +1,4 @@
-package runtime 
+package runtime
 
 import (
     "github.com/cloudson/git2go"
@@ -6,7 +6,7 @@ import (
     "log"
 )
 
-func walkRemotes(n *parser.NodeProgram, visitor *RuntimeVisitor) {
+func walkRemotes(n *parser.NodeProgram, visitor *RuntimeVisitor) *TableData{
     s := n.Child.(*parser.NodeSelect)
     where := s.Where
 
@@ -56,7 +56,10 @@ func walkRemotes(n *parser.NodeProgram, visitor *RuntimeVisitor) {
         }
         rowsSliced = rowsSliced[0:counter]
     }
-    printTable(rowsSliced, fields)
+    tableData := new(TableData)
+    tableData.rows = rowsSliced
+    tableData.fields = fields
+    return tableData
 }
 
 func metadataRemote(identifier string, object *git.Remote) string {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -73,7 +73,7 @@ func throwRuntimeError(message string, code uint8) *RuntimeError {
 }
 
 // =========================== Runtime
-func Run(n *parser.NodeProgram, genJson *bool) {
+func Run(n *parser.NodeProgram, typeFormat *string) {
 	builder = GetGitBuilder(n.Path)
 	visitor := new(RuntimeVisitor)
 	err := visitor.Visit(n)
@@ -94,7 +94,7 @@ func Run(n *parser.NodeProgram, genJson *bool) {
 		break
 	}
 
-	if *genJson {
+	if *typeFormat == "json" {
 		printJson(tableData)
 	} else {
 		printTable(tableData)
@@ -123,12 +123,14 @@ func printTable(tableData *TableData) {
 	table.Print()
 }
 
-func printJson(tableData *TableData) {
+func printJson(tableData *TableData) error {
 	res, err := json.Marshal(tableData.rows)
 	if err != nil {
 		log.Fatalln(err)
+		return throwRuntimeError(fmt.Sprintf("Json error:'%s'", err), 0)
 	} else {
 		fmt.Println(string(res))
+		return nil
 	}
 }
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -130,8 +130,8 @@ func printJson(tableData *TableData) error {
 		return throwRuntimeError(fmt.Sprintf("Json error:'%s'", err), 0)
 	} else {
 		fmt.Println(string(res))
-		return nil
 	}
+	return nil
 }
 
 func orderTable(rows []tableRow, order *parser.NodeOrder) []tableRow {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -3,6 +3,8 @@ package runtime
 import (
 	"path/filepath"
 	"testing"
+	"github.com/cloudson/gitql/parser"
+	"github.com/cloudson/gitql/semantical"
 )
 
 func TestErrorWithInvalidTables(t *testing.T) {
@@ -77,4 +79,28 @@ func TestFoundFieldsFromTable(t *testing.T) {
 			t.Errorf(err.Error())
 		}
 	}
+}
+
+func TestCanConvertToTypeFormats(t *testing.T) {
+	folder, errFile := filepath.Abs("../")
+
+	if errFile != nil {
+		t.Errorf(errFile.Error())
+	}
+
+	query := "select author from commits"
+
+	parser.New(query)
+	ast, errGit := parser.AST()
+	if errGit != nil {
+		t.Errorf(errGit.Error())
+	}
+	ast.Path = &folder
+	errGit = semantical.Analysis(ast)
+	if errGit != nil {
+		t.Errorf(errGit.Error())
+	}
+
+	typeFormat := "json"
+	Run(ast, &typeFormat)
 }


### PR DESCRIPTION
This PR adds support to json as per https://github.com/cloudson/gitql/issues/27

I also created a flag `-json` _// not sure if it is the best name for the flag_

In this way: 
 - `git ql "select author,hash from commits"` returns the classic table as its output.
 - `git ql -json "select author,hash from commits"` returns a json as its output.

Please check the image below:

![gitsql_json](https://cloud.githubusercontent.com/assets/6173065/21217220/f7d3479c-c25f-11e6-8b0b-7bb908634d3f.png)
