### PR TITLE
Migrated table rendering to olekukonko/tablewriter

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -1,13 +1,15 @@
 package runtime
 
 import (
+	"encoding/json"
 	"fmt"
+	"log"
+	"os"
+
+	"github.com/cloudson/git2go"
 	"github.com/cloudson/gitql/parser"
 	"github.com/cloudson/gitql/semantical"
-	"github.com/crackcomm/go-clitable"
-	"github.com/cloudson/git2go"
-	"log"
-	"encoding/json"
+	"github.com/olekukonko/tablewriter"
 )
 
 const (
@@ -54,7 +56,7 @@ type RuntimeVisitor struct {
 }
 
 type TableData struct {
-	rows []tableRow
+	rows   []tableRow
 	fields []string
 }
 
@@ -116,11 +118,18 @@ func findWalkType(n *parser.NodeProgram) uint8 {
 }
 
 func printTable(tableData *TableData) {
-	table := clitable.New(tableData.fields)
-	for _, r := range tableData.rows {
-		table.AddRow(r)
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAutoFormatHeaders(false)
+	table.SetHeader(tableData.fields)
+	table.SetRowLine(true)
+	for _, row := range tableData.rows {
+		rowData := make([]string, len(tableData.fields))
+		for i, field := range tableData.fields {
+			rowData[i] = fmt.Sprintf("%v", row[field])
+		}
+		table.Append(rowData)
 	}
-	table.Print()
+	table.Render()
 }
 
 func printJson(tableData *TableData) error {
@@ -263,7 +272,7 @@ func (g *GitBuilder) isProxyTable(tableName string) bool {
 	return isIn
 }
 
-func  PossibleTables() (map[string][]string) {
+func PossibleTables() map[string][]string {
 	return map[string][]string{
 		"commits": {
 			"hash",


### PR DESCRIPTION
Since github.com/crackcomm/go-clitable was deprecated in favor of github.com/olekukonko/tablewriter I went ahead and migrated table rendering.
Fixes #40 