### PR TITLE
Wildcard select causes nil

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -29,7 +29,7 @@ type Gitql struct {
 
 func (cmd *Gitql) Run() int {
 	if err := unwrap(cmd.execute()); err != nil {
-		fmt.Fprintf(os.Stderr, err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 		return 1
 	}
 	return 0

--- a/runtime/commits.go
+++ b/runtime/commits.go
@@ -23,6 +23,7 @@ func walkCommits(n *parser.NodeProgram, visitor *RuntimeVisitor) (*TableData, er
 	if s.WildCard {
 		fields = builder.possibleTables[s.Tables[0]]
 	}
+	resultFields := fields // These are the fields in output with wildcards expanded
 	rows := make([]tableRow, s.Limit)
 	usingOrder := false
 	if s.Order != nil {
@@ -67,7 +68,7 @@ func walkCommits(n *parser.NodeProgram, visitor *RuntimeVisitor) (*TableData, er
 	}
 	tableData := new(TableData)
 	tableData.rows = rowsSliced
-	tableData.fields = s.Fields
+	tableData.fields = resultFields
 	return tableData, nil
 }
 

--- a/runtime/commits_test.go
+++ b/runtime/commits_test.go
@@ -65,10 +65,10 @@ func TestRowLimitsCount(t *testing.T) {
 }
 
 func TestWildcardFieldsCount(t *testing.T) {
-	query := "select * from branches"
+	query := "select * from commits"
 	table := getTableForQuery(query, "../", t)
-	if len(table.fields) != 3 {
-		t.Errorf("Branches has 3 fields. Output table got %d fields", len(table.fields))
+	if len(table.fields) != 8 {
+		t.Errorf("Commits has 8 fields. Output table got %d fields", len(table.fields))
 	}
 }
 

--- a/runtime/commits_test.go
+++ b/runtime/commits_test.go
@@ -54,3 +54,31 @@ func TestSortOrdering(t *testing.T) {
 		}
 	}
 }
+
+func TestRowLimitsCount(t *testing.T) {
+	query := "select hash, date from commits order by date desc limit 3"
+	tableData := getTableForQuery(query, "../", t)
+
+	if len(tableData.rows) > 3 {
+		t.Error("Got more rows than the limit ")
+	}
+}
+
+func TestWildcardFieldsCount(t *testing.T) {
+	query := "select * from branches"
+	table := getTableForQuery(query, "../", t)
+	if len(table.fields) != 3 {
+		t.Errorf("Branches has 3 fields. Output table got %d fields", len(table.fields))
+	}
+}
+
+func TestSelectedFieldsCount(t *testing.T) {
+	query := "select author, hash from commits"
+	table := getTableForQuery(query, "../", t)
+	if len(table.fields) != 2 {
+		t.Errorf("Selected 2 fields. Output table got %d fields", len(table.fields))
+	}
+	if table.fields[0] != "author" || table.fields[1] != "hash" {
+		t.Errorf("Selected 'author' and 'hash'. Got %v", table.fields)
+	}
+}

--- a/runtime/commits_test.go
+++ b/runtime/commits_test.go
@@ -8,32 +8,35 @@ import (
 	"github.com/cloudson/gitql/semantical"
 )
 
-func TestSortOrdering(t *testing.T) {
-
-	failTestIfError := func(err error) {
-		if err != nil {
-			t.Error(err.Error())
-		}
+func failTestIfError(err error, t *testing.T) {
+	if err != nil {
+		t.Error(err.Error())
 	}
-	folder, errFile := filepath.Abs("../")
-	failTestIfError(errFile)
+}
 
-	query := "select hash, date from commits order by date desc limit 3"
+func getTableForQuery(query, directory string, t *testing.T) *TableData {
 	parser.New(query)
 	ast, errGit := parser.AST()
-	failTestIfError(errGit)
+	failTestIfError(errGit, t)
 
+	folder, errFile := filepath.Abs(directory)
+	failTestIfError(errFile, t)
 	ast.Path = &folder
 	errGit = semantical.Analysis(ast)
-	failTestIfError(errGit)
+	failTestIfError(errGit, t)
 
 	builder = GetGitBuilder(ast.Path)
 	visitor := new(RuntimeVisitor)
 	err := visitor.Visit(ast)
-	failTestIfError(err)
+	failTestIfError(err, t)
 
 	tableData, err := walkCommits(ast, visitor)
-	failTestIfError(err)
+	failTestIfError(err, t)
+	return tableData
+}
+func TestSortOrdering(t *testing.T) {
+	query := "select hash, date from commits order by date desc limit 3"
+	tableData := getTableForQuery(query, "../", t)
 	for i := 1; i < len(tableData.rows); i++ {
 		if tableData.rows[i]["date"].(string) > tableData.rows[i-1]["date"].(string) {
 			t.Errorf("Date not sored. row %d is bigger than row %d", i, i-1)
@@ -41,25 +44,10 @@ func TestSortOrdering(t *testing.T) {
 	}
 
 	queryWithoutDate := "select hash from commits order by date desc limit 3"
-	parser.New(queryWithoutDate)
-	ast, errGit = parser.AST()
-	failTestIfError(errGit)
-
-	ast.Path = &folder
-	errGit = semantical.Analysis(ast)
-	failTestIfError(errGit)
-
-	builder = GetGitBuilder(ast.Path)
-	visitor = new(RuntimeVisitor)
-	err = visitor.Visit(ast)
-	failTestIfError(err)
-
-	tableDataNew, err := walkCommits(ast, visitor)
-	failTestIfError(err)
+	tableDataNew := getTableForQuery(queryWithoutDate, "../", t)
 	if len(tableData.rows) != len(tableDataNew.rows) {
 		t.Error("Two queried returned different number of rows")
 	}
-
 	for i := 0; i < len(tableData.rows); i++ {
 		if tableDataNew.rows[i]["hash"].(string) != tableData.rows[i]["hash"].(string) {
 			t.Errorf("Data in row %d does not match on both tables", i)


### PR DESCRIPTION
After walking commits, return expanded fields instead of the raw fields from input which might have wildcards.

Fixes #55 