### PR TITLE
Add not equals validation

### DIFF
--- a/lexical/lexical.go
+++ b/lexical/lexical.go
@@ -142,6 +142,9 @@ func Token() (uint8, *TokenError) {
 			if lexeme == "=" {
 				state = S_SMALLER_OR_EQUAL
 				break
+			} else if lexeme == ">" {
+				char = nextChar()
+				return T_NOT_EQUAL, nil
 			}
 			return T_SMALLER, nil
 		case S_SMALLER_OR_EQUAL:

--- a/parser/ast.go
+++ b/parser/ast.go
@@ -175,6 +175,9 @@ func (n *NodeEqual) LeftValue() NodeExpr {
 
 // NOT EQUAL
 func (n *NodeNotEqual) Assertion(lvalue string, rvalue string) bool {
+	if len(lvalue) == 40 {
+		return lvalue[0:len(rvalue)] != rvalue
+	}
 	return lvalue != rvalue
 }
 

--- a/runtime/commits_test.go
+++ b/runtime/commits_test.go
@@ -84,6 +84,16 @@ func TestSelectedFieldsCount(t *testing.T) {
 	}
 }
 
+func TestNotEqualsInWhereLTGT(t *testing.T) {
+	queryData := "select committer, hash from commits limit 1"
+	table := getTableForQuery(queryData, "../", t)
+	firstCommitter := table.rows[0]["committer"].(string)
+	query := fmt.Sprintf("select committer, hash from commits where committer <> '%s' limit 1", firstCommitter)
+	table = getTableForQuery(query, "../", t)
+	if firstCommitter == table.rows[0]["committer"].(string) {
+		t.Errorf("Still got the same committer as the first one. - %s", firstCommitter)
+	}
+}
 func TestNotEqualsInWhere(t *testing.T) {
 	queryData := "select committer, hash from commits limit 1"
 	table := getTableForQuery(queryData, "../", t)
@@ -91,6 +101,6 @@ func TestNotEqualsInWhere(t *testing.T) {
 	query := fmt.Sprintf("select committer, hash from commits where committer != '%s' limit 1", firstCommitter)
 	table = getTableForQuery(query, "../", t)
 	if firstCommitter == table.rows[0]["committer"].(string) {
-		t.Errorf("Strill got the same committer as the first one. - %s", firstCommitter)
+		t.Errorf("Still got the same committer as the first one. - %s", firstCommitter)
 	}
 }

--- a/runtime/commits_test.go
+++ b/runtime/commits_test.go
@@ -30,7 +30,7 @@ func getTableForQuery(query, directory string, t *testing.T) *TableData {
 	visitor := new(RuntimeVisitor)
 	err := visitor.Visit(ast)
 	failTestIfError(err, t)
-
+	findWalkType(ast)
 	tableData, err := walkCommits(ast, visitor)
 	failTestIfError(err, t)
 	return tableData

--- a/runtime/commits_test.go
+++ b/runtime/commits_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -80,5 +81,16 @@ func TestSelectedFieldsCount(t *testing.T) {
 	}
 	if table.fields[0] != "author" || table.fields[1] != "hash" {
 		t.Errorf("Selected 'author' and 'hash'. Got %v", table.fields)
+	}
+}
+
+func TestNotEqualsInWhere(t *testing.T) {
+	queryData := "select committer, hash from commits limit 1"
+	table := getTableForQuery(queryData, "../", t)
+	firstCommitter := table.rows[0]["committer"].(string)
+	query := fmt.Sprintf("select committer, hash from commits where committer != '%s' limit 1", firstCommitter)
+	table = getTableForQuery(query, "../", t)
+	if firstCommitter == table.rows[0]["committer"].(string) {
+		t.Errorf("Strill got the same committer as the first one. - %s", firstCommitter)
 	}
 }

--- a/runtime/visitor.go
+++ b/runtime/visitor.go
@@ -67,7 +67,6 @@ func testAllFieldsFromTable(fields []string, table string) error {
 			return err
 		}
 	}
-
 	return nil
 }
 

--- a/runtime/visitor.go
+++ b/runtime/visitor.go
@@ -91,7 +91,9 @@ func (v *RuntimeVisitor) VisitExpr(n parser.NodeExpr) error {
 	case reflect.TypeOf(new(parser.NodeIn)):
 		g := n.(*parser.NodeIn)
 		return v.VisitIn(g)
-
+	case reflect.TypeOf(new(parser.NodeNotEqual)):
+		g := n.(*parser.NodeNotEqual)
+		return v.VisitNotEqual(g)
 	}
 
 	return nil
@@ -101,7 +103,13 @@ func (v *RuntimeVisitor) VisitEqual(n *parser.NodeEqual) error {
 	lvalue := n.LeftValue().(*parser.NodeId).Value()
 	rvalue := n.RightValue().(*parser.NodeLiteral).Value()
 	boolRegister = n.Assertion(metadata(lvalue), rvalue)
+	return nil
+}
 
+func (v *RuntimeVisitor) VisitNotEqual(n *parser.NodeNotEqual) error {
+	lvalue := n.LeftValue().(*parser.NodeId).Value()
+	rvalue := n.RightValue().(*parser.NodeLiteral).Value()
+	boolRegister = n.Assertion(metadata(lvalue), rvalue)
 	return nil
 }
 


### PR DESCRIPTION
Add Not equals validation to the where clause.

```
gitql "select committer from commits where committer != 'Arumugam J' order by date desc limit 1"
+-----------+
| committer |
+-----------+
| GitHub    |
+-----------+
```
It was originally not validating the where clause if it has a `!=` sign. Fixes #58 