### PR TITLE
Little more meaningful message for parsing error

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -495,13 +496,9 @@ func rValue() (NodeExpr, error) {
 		return n, nil
 	}
 
-	if look_ahead != lexical.T_LITERAL && look_ahead != lexical.T_NUMERIC {
-		return nil, throwSyntaxError(lexical.T_LITERAL, look_ahead)
-	}
-
 	lexeme := lexical.CurrentLexeme
 	if look_ahead != lexical.T_LITERAL {
-		return nil, throwSyntaxError(lexical.T_AND, look_ahead)
+		return nil, errors.New("Only Literals and Date are allowed in `where` clause")
 	}
 
 	// @todo inserts IS NULL!


### PR DESCRIPTION
Fixes #72 
```
./gitql "select name from commit where name < 2"
Only Literals and Date are allowed in `where` clause

./gitql "select hash from commits where name < '2'"
RValue in Smaller should be numeric or a date

./gitql "select hash from commits where name = '2'"
2018/10/19 01:12:01 Table 'commits' has not field 'name'
```