### PR TITLE
Set proper GOPATH in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ export DYLD_LIBRARY_PATH=$(PWD)/libgit2/install/lib
 export PKG_CONFIG_PATH=$(PWD)/libgit2/install/lib/pkgconfig
 URL_BASE_GIT2GO=https://github.com/libgit2/git2go/archive
 GIT2GO_VERSION=master
+GOPATH=$(shell go env GOPATH)
+
 all: prepare build
 
 test: 


### PR DESCRIPTION
fixes #74 
By executing `go env GOPATH` it makes it compatible with all the version of go.