### PR TITLE
Add support to dynamic compile for mac

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,9 @@
 name: CI
 on: [push]
 jobs:
-   test:
-    strategy:
-      matrix:
-        platform: [ubuntu-latest]
-    runs-on: ${{ matrix.platform }}
+  build-linux:
+    name: Build linux
+    runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.12
       uses: actions/setup-go@v1
@@ -27,5 +25,37 @@ jobs:
         GOPATH: /home/runner/work/cloudson/go
         TARGET_OS_ARCH: linux/amd64
       run: | 
-        ./install.sh 
+        make build
+        ./gitql -v
+
+  build-mac:
+    name: Build mac
+    runs-on: macos-latest
+    steps:
+    - name: Set up Go 1.12
+      uses: actions/setup-go@v1
+      with:
+        version: 1.12
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v1
+      with:
+        path: go/src/github.com/cloudson/gitql
+    
+    - name: Run tests
+      run: | 
+        make test
+
+    - name: Build mac
+      env:
+        TARGET_OS_ARCH: darwin/amd64
+      run: | 
+        brew install pkg-config gcc
+        export PKG_CONFIG_PATH=${PWD}/libgit2/install/lib/pkgconfig:/usr/local/opt/openssl/lib/pkgconfig
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(PWD)/libgit2/install/lib
+        echo ${PKG_CONFIG_PATH}
+        make build-dynamic || true
+        pkg-config --version
+        openssl version
         ./gitql -v

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,36 @@
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(PWD)/libgit2/install/lib
 export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$(PWD)/libgit2/install/lib
-export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$(PWD)/libgit2/install/lib/pkgconfig
+# export PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig
 export C_INCLUDE_PATH=$C_INCLUDE_PATH:$(PWD)/libgit2/install/include
 URL_BASE_GIT2GO=https://github.com/libgit2/git2go/archive
 GIT2GO_VERSION=master
 GOPATH=$(shell go env GOPATH)
 
-all: prepare build
+all: build
 
 test: 
 	@go test -count=1 -v ./parser/ ./lexical/ ./utilities/ ./semantical/ 
 
-clean:
-	@rm -rf ./libgit2
-
-prepare: clean
-	@echo "Preparing...\n"
-	@chmod +x $(GOPATH)/src/github.com/cloudson/git2go/script/build-libgit2.sh
-	@$(GOPATH)/src/github.com/cloudson/git2go/script/build-libgit2.sh
-
 build: 
 	@echo "Building..."
 	@bash install.sh
+
+clean:
+	@rm -rf ./libgit2
+	@rm -rf install-libgit2.sh
+
+prepare-dynamic: clean
+	@echo "Preparing...\n"
+	@rm go.mod go.sum || echo 0
+	@curl https://raw.githubusercontent.com/cloudson/git2go/original_libgit2/script/install-libgit2.sh >> install-libgit2.sh
+	@chmod +x ./install-libgit2.sh
+	@bash ./install-libgit2.sh
+	@ls ${PWD}/libgit2/install/lib/pkgconfig
+	@echo $(PKG_CONFIG_PATH)
+
+build-dynamic: prepare-dynamic
+	@pwd
+	@ls ${PWD}/libgit2/install/lib/pkgconfig
+	@echo $(PKG_CONFIG_PATH)
+	@go get -v -d . 
+	@go build


### PR DESCRIPTION
Even now that we have a static way to compile gitql to linux/amd64, we still need to keep the support to mac os with dynamic linking to libgit2. 

See more here: https://stackoverflow.com/questions/3801011/ld-library-not-found-for-lcrt0-o-on-osx-10-6-with-gcc-clang-static-flag