### PR TITLE
Add support to static binaries (windows/linux amd64) 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,11 @@ jobs:
       run: | 
         make build
         ./gitql -v
+    - uses: actions/upload-artifact@master
+      name: Generating artifact
+      with:
+        name: gitql-linux64
+        path: ./gitql
 
   build-mac:
     name: Build mac
@@ -57,7 +62,12 @@ jobs:
         export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$(PWD)/libgit2/install/lib
         make build-dynamic || true
         ./gitql -v
-    
+    - uses: actions/upload-artifact@master
+      name: Generating artifact
+      with:
+        name: gitql-mac64
+        path: ./gitql
+
   build-windows:
     name: Build windows
     runs-on: windows-2019
@@ -80,8 +90,12 @@ jobs:
         TARGET_OS_ARCH: windows/amd64
       run: | 
         choco install ninja vcredist2017
-        ls %ALLUSERSPROFILE%\MinGW\bin
         set PATH=%HOMEDRIVE%\mingw64\bin;%PATH%
-        echo %PATH%
         make build
-        gitql -v
+        .\gitql.exe -v
+
+    - uses: actions/upload-artifact@master
+      name: Generating artifact
+      with:
+        name: gitql-win64
+        path: .\gitql.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,31 @@ jobs:
         export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$(PWD)/libgit2/install/lib
         make build-dynamic || true
         ./gitql -v
+    
+  build-windows:
+    name: Build windows
+    runs-on: windows-2019
+    steps:
+    - name: Set up Go 1.12
+      uses: actions/setup-go@v1
+      with:
+        version: 1.12
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v1
+    
+    - name: Run tests
+      run: | 
+        make test
+
+    - name: Build windows
+      env:
+        TARGET_OS_ARCH: windows/amd64
+      run: | 
+        choco install ninja vcredist2017
+        ls %ALLUSERSPROFILE%\MinGW\bin
+        set PATH=%HOMEDRIVE%\mingw64\bin;%PATH%
+        echo %PATH%
+        make build
+        gitql -v

--- a/README.md
+++ b/README.md
@@ -15,10 +15,12 @@ See more [here](https://asciinema.org/a/97094)
 - pkg-config  
 
 ## How to install
+
+We support static compiling for linux and windows platform (amd64), so you can access the [releases page](https://github.com/cloudson/gitql/releases) and just grab the binary. If you want to compile itself follow the instructions below: 
+
 ### linux/amd64 
 
-We support static compiling for linux architetures, so you can access the [releases page](https://github.com/cloudson/gitql/releases). If you want to compile itself, take a look in the dockerfile to
-understand the whole process. 
+Read the dockerfile to understand the whole process. 
 
 ### darwin/amd64
 
@@ -32,8 +34,18 @@ export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$(PWD)/libgit2/install/lib
 make build-dynamic
 ```
 
+### windows/amd64
+
+You need a C compiler, Cmake and Ninja installed. Using chocolately it should be easy 
+
+```bash
+choco install cmake ninja vcredist2017
+set PATH=%HOMEDRIVE%\mingw64\bin;%PATH%
+make build
+```
+
 You can always take a look in our [github actions file](./.github/workflows/ci.yml) to understand
-how we build it in the ci server.
+how we build it in the ci server. If even after try [the binaries](https://github.com/cloudson/gitql/releases) or either compile yourself you couldn't use that. Open an issue. 
 
 ## Examples 
 
@@ -66,7 +78,7 @@ As an example, this is the `commits` table:
 
 ## Questions?
 
-`gitql -h` or open an [issue](https://github.com/cloudson/gitql/issues)
+`gitql` or open an [issue](https://github.com/cloudson/gitql/issues)
 
 Notes:
 * Gitql doesn't want to _kill_ `git log` - it was created just for science! :sweat_smile:

--- a/install.sh
+++ b/install.sh
@@ -71,7 +71,6 @@ build_libgit2_windows(){
   -DUSE_ICONV=OFF \
   -DWINHTTP=OFF \
   -DCMAKE_SYSTEM_NAME=Windows \
-  -DCMAKE_C_COMPILER=${CC} \
   -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
   -DCMAKE_INSTALL_PREFIX="${LIBGIT2_STATIC_PREFIX}" \
   -DWIN32=ON \
@@ -123,7 +122,8 @@ build_libgit2(){
     build_libgit2_darwin
   ;;
   windows/amd64*)
-    export GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-clang
+    export GOOS=windows GOARCH=amd64 
+    # CC=x86_64-w64-mingw32-clang
     FLAGS="-lws2_32"
     export CGO_LDFLAGS="${LIBGIT2_STATIC_PREFIX}/lib/libgit2.a -L${LIBGIT2_STATIC_PREFIX}/include ${FLAGS}"
     build_libgit2_windows


### PR DESCRIPTION
After a long winter, this pull request provides support to build a static binary for windows and linux on every pull request. They might be easily downloaded in the github actions artifacts section and be used directly without any previous configuration. 

To achive this, I'm removing a minor feature (support to remotes tables), and because of that, the intent is to release this as a v2.0.0. 

Next steps is to create acceptance tests using the binaries to make sure that gitql returns always the same values for specific queries. 